### PR TITLE
Add SQL schema for Freeblis API

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Vendors list products on Freeblis. Clients can claim these products by scanning 
 - **claims:** user_id, product_id, claim_time, claim_token
 - **qr_codes:** product_id, token, status (active/claimed)
 - **sessions:** for token validation or JWT blacklist if needed
+- **password_logs:** audit trail for password changes
 
 ---
 
@@ -84,7 +85,7 @@ Vendors list products on Freeblis. Clients can claim these products by scanning 
     DB_USERNAME=root
     DB_PASSWORD=
     ```
-4. Run migrations to set up the database.
+4. Import `database/schema.sql` to create the tables.
 5. Start the server.
 
 ## 📄 License

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,68 @@
+-- SQL schema for Freeblis API
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) NOT NULL UNIQUE,
+    email VARCHAR(100) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role ENUM('client','vendor','admin') NOT NULL DEFAULT 'client',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS user_profiles (
+    user_id INT PRIMARY KEY,
+    full_name VARCHAR(100),
+    date_of_birth DATE,
+    phone VARCHAR(30),
+    address VARCHAR(255),
+    profile_image VARCHAR(255),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS products (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    vendor_id INT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    price DECIMAL(10,2) DEFAULT 0,
+    stock INT DEFAULT 0,
+    category VARCHAR(100),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (vendor_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS qr_codes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    product_id INT NOT NULL,
+    token VARCHAR(64) NOT NULL UNIQUE,
+    status ENUM('active','claimed') NOT NULL DEFAULT 'active',
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS claims (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    product_id INT NOT NULL,
+    claim_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    claim_token VARCHAR(64) NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    token VARCHAR(255) NOT NULL,
+    expires_at DATETIME,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS password_logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    changed_by VARCHAR(100) NOT NULL,
+    ip_address VARCHAR(45) NOT NULL,
+    user_agent VARCHAR(255) NOT NULL,
+    changed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+


### PR DESCRIPTION
## Summary
- add SQL schema defining all tables for the API
- document the `password_logs` table and update setup instructions

## Testing
- `php -l bootstrap.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840134681b8832f861dc3e38461bd5e